### PR TITLE
fix: skip permission test on Windows and normalize paths for consistent matching

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,8 +49,8 @@ func findConfigFile() string {
 
 // matchPattern checks if a file matches the pattern
 func (c *Config) matchPattern(pattern, filePath string) bool {
-	// Normalize path
-	filePath = filepath.Clean(filePath)
+	// Normalize path - convert backslashes to forward slashes for consistent matching
+	filePath = filepath.ToSlash(filepath.Clean(filePath))
 
 	// Use doublestar for pattern matching
 	matched, _ := doublestar.Match(pattern, filePath)
@@ -59,8 +59,8 @@ func (c *Config) matchPattern(pattern, filePath string) bool {
 
 // ShouldIgnore checks if a file or directory should be ignored
 func (c *Config) ShouldIgnore(filePath string) bool {
-	// Normalize path
-	filePath = filepath.Clean(filePath)
+	// Normalize path - convert backslashes to forward slashes for consistent matching
+	filePath = filepath.ToSlash(filepath.Clean(filePath))
 
 	for _, pattern := range c.Ignore {
 		if c.matchPattern(pattern, filePath) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -137,6 +138,11 @@ func TestLoadConfig(t *testing.T) {
 	})
 
 	t.Run("permission denied", func(t *testing.T) {
+		// Skip this test on Windows as permission handling is different
+		if runtime.GOOS == "windows" {
+			t.Skip("Skipping permission test on Windows")
+		}
+
 		// Change to temporary directory
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
fix: skip permission test on Windows and normalize paths for consistent matching